### PR TITLE
Add builderPath option

### DIFF
--- a/lib/docker/DockerBuild.ts
+++ b/lib/docker/DockerBuild.ts
@@ -55,6 +55,7 @@ const DefaultDockerOptions: DockerOptions = {
     push: false,
     builder: "docker",
     builderArgs: [],
+    builderPath: ".",
 };
 
 /**

--- a/lib/docker/executeDockerBuild.ts
+++ b/lib/docker/executeDockerBuild.ts
@@ -119,7 +119,6 @@ export function executeDockerBuild(options: DockerOptions): ExecuteGoal {
         const { goalEvent, context, project } = gi;
 
         const optsToUse = mergeOptions<DockerOptions>(options, {}, "docker.build");
-        optsToUse.builderPath = (optsToUse.builderPath) ? optsToUse.builderPath : ".";
 
         switch (optsToUse.builder) {
             case "docker":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-docker",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-docker",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Extension Pack for an Atomist SDM to integrate Docker",
   "author": {
     "name": "Atomist",


### PR DESCRIPTION
All user to supply optional builder path relative to project base
directory for both docker and kaniko builds.

Increment minor version since this is a new feature.

Closes #42